### PR TITLE
python import pyspark fails

### DIFF
--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -25,7 +25,7 @@ import threading
 from threading import RLock
 from tempfile import NamedTemporaryFile
 
-from pyspark import accumulators
+import pyspark.accumulators as accumulators
 from pyspark.accumulators import Accumulator
 from pyspark.broadcast import Broadcast
 from pyspark.conf import SparkConf


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

import pyspark
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "pyspark/**init**.py", line 44, in <module>
    from pyspark.context import SparkContext
  File "pyspark/context.py", line 28, in <module>
    from pyspark import accumulators
ImportError: cannot import name accumulators
